### PR TITLE
feat: Add homepage with open project functionality and basic editor

### DIFF
--- a/engine-editor/Cargo.toml
+++ b/engine-editor/Cargo.toml
@@ -5,13 +5,15 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-leptos = { version = "0.7", features = ["csr"] }
+leptos = { version = "0.6.12", features = ["csr"] }
+leptos_router = { version = "0.6.12" }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
 console_error_panic_hook = "0.1.7"
+web-sys = { version = "0.3", features = ["KeyboardEvent"] }
 
 [workspace]
 members = ["src-tauri"]

--- a/engine-editor/package-lock.json
+++ b/engine-editor/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "engine-editor",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/engine-editor/src-tauri/Cargo.toml
+++ b/engine-editor/src-tauri/Cargo.toml
@@ -19,6 +19,8 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 tauri = { version = "2", features = [] }
+tauri-plugin-dialog = "2"
+tauri-plugin-fs = "2"
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/engine-editor/src-tauri/src/lib.rs
+++ b/engine-editor/src-tauri/src/lib.rs
@@ -1,14 +1,68 @@
+use std::fs;
+use serde::{Deserialize, Serialize};
+use tauri_plugin_dialog::Dialog;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct DirEntry {
+    path: String,
+    is_dir: bool,
+    name: String,
+}
+
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
 #[tauri::command]
 fn greet(name: &str) -> String {
     format!("Hello, {}! You've been greeted from Rust!", name)
 }
 
+#[tauri::command]
+async fn open_project(dialog: Dialog) -> Option<String> {
+    if let Some(path) = dialog.file().pick_dir().await {
+        return Some(path.to_string_lossy().to_string());
+    }
+    None
+}
+
+#[tauri::command]
+fn read_dir(path: &str) -> Result<Vec<DirEntry>, String> {
+    let mut entries = vec![];
+    for entry in fs::read_dir(path).map_err(|e| e.to_string())? {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let path = entry.path();
+        let name = path.file_name().unwrap().to_string_lossy().to_string();
+        let is_dir = path.is_dir();
+        entries.push(DirEntry {
+            path: path.to_string_lossy().to_string(),
+            is_dir,
+            name,
+        });
+    }
+    Ok(entries)
+}
+
+#[tauri::command]
+fn read_file_content(path: &str) -> Result<String, String> {
+    fs::read_to_string(path).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+fn write_file_content(path: &str, content: &str) -> Result<(), String> {
+    fs::write(path, content).map_err(|e| e.to_string())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
-        .invoke_handler(tauri::generate_handler![greet])
+        .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_fs::init())
+        .invoke_handler(tauri::generate_handler![
+            greet,
+            open_project,
+            read_dir,
+            read_file_content,
+            write_file_content
+        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/engine-editor/src/app.rs
+++ b/engine-editor/src/app.rs
@@ -1,67 +1,18 @@
-use leptos::task::spawn_local;
-use leptos::{ev::SubmitEvent, prelude::*};
-use serde::{Deserialize, Serialize};
-use wasm_bindgen::prelude::*;
-
-#[wasm_bindgen]
-extern "C" {
-    #[wasm_bindgen(js_namespace = ["window", "__TAURI__", "core"])]
-    async fn invoke(cmd: &str, args: JsValue) -> JsValue;
-}
-
-#[derive(Serialize, Deserialize)]
-struct GreetArgs<'a> {
-    name: &'a str,
-}
+use crate::editor::Editor;
+use crate::home::Home;
+use leptos::prelude::*;
+use leptos_router::*;
 
 #[component]
 pub fn App() -> impl IntoView {
-    let (name, set_name) = signal(String::new());
-    let (greet_msg, set_greet_msg) = signal(String::new());
-
-    let update_name = move |ev| {
-        let v = event_target_value(&ev);
-        set_name.set(v);
-    };
-
-    let greet = move |ev: SubmitEvent| {
-        ev.prevent_default();
-        spawn_local(async move {
-            let name = name.get_untracked();
-            if name.is_empty() {
-                return;
-            }
-
-            let args = serde_wasm_bindgen::to_value(&GreetArgs { name: &name }).unwrap();
-            // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
-            let new_msg = invoke("greet", args).await.as_string().unwrap();
-            set_greet_msg.set(new_msg);
-        });
-    };
-
     view! {
-        <main class="container">
-            <h1>"Welcome to Tauri + Leptos"</h1>
-
-            <div class="row">
-                <a href="https://tauri.app" target="_blank">
-                    <img src="public/tauri.svg" class="logo tauri" alt="Tauri logo"/>
-                </a>
-                <a href="https://docs.rs/leptos/" target="_blank">
-                    <img src="public/leptos.svg" class="logo leptos" alt="Leptos logo"/>
-                </a>
-            </div>
-            <p>"Click on the Tauri and Leptos logos to learn more."</p>
-
-            <form class="row" on:submit=greet>
-                <input
-                    id="greet-input"
-                    placeholder="Enter a name..."
-                    on:input=update_name
-                />
-                <button type="submit">"Greet"</button>
-            </form>
-            <p>{ move || greet_msg.get() }</p>
-        </main>
+        <Router>
+            <main>
+                <Routes>
+                    <Route path="/editor" view=Editor/>
+                    <Route path="/" view=Home/>
+                </Routes>
+            </main>
+        </Router>
     }
 }

--- a/engine-editor/src/editor.rs
+++ b/engine-editor/src/editor.rs
@@ -1,0 +1,124 @@
+use leptos::ev::event_target_value;
+use leptos::prelude::*;
+use leptos_router::use_query_map;
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsValue;
+use std::path::Path;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = ["window", "__TAURI__", "core"])]
+    async fn invoke(cmd: &str, args: JsValue) -> JsValue;
+}
+
+#[derive(Serialize)]
+struct ReadDirArgs<'a> {
+    path: &'a str,
+}
+
+#[derive(Serialize)]
+struct ReadFileContentArgs<'a> {
+    path: &'a str,
+}
+
+#[derive(Serialize)]
+struct WriteFileContentArgs<'a> {
+    path: &'a str,
+    content: &'a str,
+}
+
+#[derive(Deserialize, Clone, Debug, PartialEq)]
+struct DirEntry {
+    path: String,
+    is_dir: bool,
+    name: String,
+}
+
+#[component]
+pub fn Editor() -> impl IntoView {
+    let query = use_query_map();
+    let path = move || {
+        query.with(|q| {
+            q.get("path")
+                .and_then(|p| js_sys::decode_uri_component(p).ok())
+                .unwrap_or_default()
+        })
+    };
+
+    let (files, set_files) = create_signal(Vec::<DirEntry>::new());
+    let (selected_file, set_selected_file) = create_signal(None::<String>);
+    let (file_content, set_file_content) = create_signal(String::new());
+
+    create_effect(move |_| {
+        let p = path();
+        if !p.is_empty() {
+            spawn_local(async move {
+                let args = serde_wasm_bindgen::to_value(&ReadDirArgs { path: &p }).unwrap();
+                let result = invoke("read_dir", args).await;
+                match serde_wasm_bindgen::from_value(result) {
+                    Ok(files_val) => set_files.set(files_val),
+                    Err(e) => web_sys::console::error_1(&e.into()),
+                }
+            });
+        }
+    });
+
+    let on_file_click = move |file: DirEntry| {
+        if !file.is_dir {
+            spawn_local(async move {
+                let args =
+                    serde_wasm_bindgen::to_value(&ReadFileContentArgs { path: &file.path }).unwrap();
+                let result = invoke("read_file_content", args).await;
+                if let Some(content) = result.as_string() {
+                    set_selected_file.set(Some(file.path));
+                    set_file_content.set(content);
+                } else {
+                    web_sys::console::error_1(&"Failed to read file content".into());
+                }
+            });
+        }
+    };
+
+    let on_save = move |ev: web_sys::KeyboardEvent| {
+        if ev.key() == "s" && ev.ctrl_key() {
+            ev.prevent_default();
+            if let Some(path) = selected_file.get_untracked() {
+                let content = file_content.get_untracked();
+                spawn_local(async move {
+                    let args = serde_wasm_bindgen::to_value(&WriteFileContentArgs {
+                        path: &path,
+                        content: &content,
+                    })
+                    .unwrap();
+                    invoke("write_file_content", args).await;
+                });
+            }
+        }
+    };
+
+    view! {
+        <div class="editor-container">
+            <div class="file-tree">
+                <h3>{ path }</h3>
+                <ul>
+                    {move || {
+                        files.get().into_iter().map(|f| {
+                            let f_clone = f.clone();
+                            view! {
+                                <li on:click=move |_| on_file_click(f_clone.clone())>{f.name}</li>
+                            }
+                        }).collect::<Vec<_>>()
+                    }}
+                </ul>
+            </div>
+            <div class="editor">
+                <textarea
+                    on:keydown=on_save
+                    on:input=move |ev| set_file_content.set(event_target_value(&ev))
+                    prop:value=move || file_content.get()
+                ></textarea>
+            </div>
+        </div>
+    }
+}

--- a/engine-editor/src/home.rs
+++ b/engine-editor/src/home.rs
@@ -1,0 +1,35 @@
+use leptos::prelude::*;
+use leptos::task::spawn_local;
+use leptos_router::{use_navigate, NavigateOptions};
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsValue;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = ["window", "__TAURI__", "core"])]
+    async fn invoke(cmd: &str, args: JsValue) -> JsValue;
+}
+
+#[component]
+pub fn Home() -> impl IntoView {
+    let navigate = use_navigate();
+
+    let open_project = move |_| {
+        spawn_local(async move {
+            let result = invoke("open_project", JsValue::NULL).await;
+            if !result.is_null() && !result.is_undefined() {
+                if let Some(path) = result.as_string() {
+                    let encoded_path = js_sys::encode_uri_component(&path);
+                    navigate(&format!("/editor?path={}", encoded_path), Default::default());
+                }
+            }
+        });
+    };
+
+    view! {
+        <div>
+            <h1>"Bimo Editor"</h1>
+            <button on:click=open_project>"Open Project"</button>
+        </div>
+    }
+}

--- a/engine-editor/src/main.rs
+++ b/engine-editor/src/main.rs
@@ -1,4 +1,6 @@
 mod app;
+mod editor;
+mod home;
 
 use app::*;
 use leptos::prelude::*;

--- a/engine-editor/styles.css
+++ b/engine-editor/styles.css
@@ -91,6 +91,33 @@ button {
   margin-right: 5px;
 }
 
+.editor-container {
+    display: flex;
+    height: 100vh;
+}
+
+.file-tree {
+    width: 200px;
+    border-right: 1px solid #ccc;
+    padding: 10px;
+    overflow-y: auto;
+}
+
+.editor {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+.editor textarea {
+    flex-grow: 1;
+    width: 100%;
+    height: 100%;
+    border: none;
+    padding: 10px;
+    font-family: monospace;
+}
+
 @media (prefers-color-scheme: dark) {
   :root {
     color: #f6f6f6;


### PR DESCRIPTION
This commit introduces a new homepage with an "Open Project" button that allows users to select a directory from their file system.

Once a directory is selected, the application navigates to a new editor view that displays the contents of the selected directory. Users can click on a file to view its content in a text area and save changes by pressing Ctrl + S.

This commit includes:
- A new `Home` component with the "Open Project" button.
- A new `Editor` component with a file tree and a text area for editing files.
- Tauri commands for opening the file dialog, reading directories, and reading/writing files.
- Client-side routing using `leptos_router` to navigate between the homepage and the editor.
- Basic CSS for the editor layout.