### PR TITLE
fix: Prevent browser-specific code from running in non-browser enviro…

### DIFF
--- a/engine-editor/src/main.rs
+++ b/engine-editor/src/main.rs
@@ -6,10 +6,13 @@ use app::*;
 use leptos::*;
 
 fn main() {
-    console_error_panic_hook::set_once();
-    mount_to_body(|| {
-        view! {
-            <App/>
-        }
-    })
+    #[cfg(target_arch = "wasm32")]
+    {
+        console_error_panic_hook::set_once();
+        mount_to_body(|| {
+            view! {
+                <App/>
+            }
+        })
+    }
 }


### PR DESCRIPTION
…nment

The `main` function in `engine-editor/src/main.rs` was calling `mount_to_body`, a Leptos function that can only be run in a browser. This caused the `cargo run tauri` command to fail because it was trying to build the code for a non-browser target.

This commit fixes the issue by wrapping the body of the `main` function in a `#[cfg(target_arch = "wasm32")]` block. This ensures that the browser-specific code is only compiled when the target is WebAssembly, and the Tauri application can build and run successfully.